### PR TITLE
Move content to GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+_site/
+.sass-cache/
+.jekyll-cache/
+.jekyll-metadata
+
+# These could be deleted later if more customization is wanted
+404.html
+Gemfile.lock
+LICENSE.txt
+_includes/
+_layouts/
+_sass/
+assets/
+favicon_package_v0/
+minima.gemspec
+script/
+

--- a/AD-AE-Appendices_Authors.md
+++ b/AD-AE-Appendices_Authors.md
@@ -1,4 +1,9 @@
-# AD/AE Appendices Author FAQ
+---
+layout: page
+title: AD/AE Appendices Author FAQ
+permalink: /ad-ae-appendices-author/
+---
+
 If you still have questions, you can email: ad-ae-appendices@info.supercomputing.org
 
 > Artifact Description (AD) Appendices are required for all papers submitted to the Technical Program at SC19.

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'github-pages', group: :jekyll_plugins
+

--- a/Papers_Authors.md
+++ b/Papers_Authors.md
@@ -1,5 +1,8 @@
-Technical Papers Author FAQ
-===========================
+---
+layout: page
+title: Technical Papers Author FAQ
+permalink: /tech-papers-author/
+---
 
 If you still have questions, you can email papers@info.supercomputing.org
 

--- a/Posters_Authors.md
+++ b/Posters_Authors.md
@@ -1,4 +1,8 @@
-# Posters FAQ
+---
+layout: page
+title: Posters Author FAQ
+permalink: /posters-author/
+---
 
 Find answers to common questions that may arise during the effort to prepare and submit a poster and scientific visualization and data analytics showcases  to the SC19 Conference. If your question is not addressed here, please contact us at posters@info.supercomputing.org.
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ Frequently Asked Questions for authors, reviewers, and committee members of the 
 * [Technical Papers FAQs](Papers_Authors.md)
 * [AD/AE Appendices FAQs](AD-AE-Appendices_Authors.md)
 * [Posters FAQs](Posters_Authors.md)
+
+
+## Adding Content
+
+To add content to this website, create a pull request in this repository. Add the content to the
+particular area where applicable by looking for the file in the top level folder (e.g. posters.md).
+
+Use the same header for each new file as what can be found in one of the existing files.

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,42 @@
+title: SC19 Tech Program FAQs
+author: SC19 Tech Program
+# email: noone@nowhere.com
+description: > # this means to ignore newlines until "twitter_username:"
+    Frequently asked questions about submissions for the SC19 technical program.
+
+# social links
+twitter_username: Supercomputing
+# dribbble_username:
+# facebook_username:
+# flickr_username:
+# instagram_username:
+# linkedin_username:
+# pinterest_username:
+# youtube_username:
+# youtube_channel:
+# youtube_channel_name:
+# telegram_username:
+
+# Mastodon instances
+# mastodon:
+# - username:
+#   instance:
+
+show_excerpts: false # set to true to show excerpts on the homepage
+
+# Minima date format
+# refer to http://shopify.github.io/liquid/filters/date/ if you want to customize this
+minima:
+  date_format: "%b %-d, %Y"
+
+# If you want to link only specific pages in your header, uncomment
+# this and add the path to the pages in order as they should show up
+header_pages:
+ - none.md
+
+# Build settings
+theme: minima
+
+plugins:
+ - jekyll-feed
+ - jekyll-seo-tag

--- a/index.md
+++ b/index.md
@@ -1,0 +1,12 @@
+---
+title: SC19 Technical Program FAQs
+layout: home
+---
+
+Frequently Asked Questions for authors, reviewers, and committee members of the SC Conference.
+
+## For Authors
+* [Technical Papers FAQs](tech-papers-author)
+* [AD/AE Appendices FAQs](ad-ae-appendices-author)
+* [Posters FAQs](posters-author)
+


### PR DESCRIPTION
Use GitHub Pages for nicer viewing. You can see how this will look here:

http://www.wesbland.com/faq-demo/

Obviously, as soon as this is merged, I'll take down my version so there's no confusion.

Once this PR is merged, the repository admin will need to turn on GitHub Pages in the repository settings. Instructions can be found here:

https://help.github.com/articles/configuring-a-publishing-source-for-github-pages/#enabling-github-pages-to-publish-your-site-from-master-or-gh-pages

If you want to try out edits before they're published on the website, you can set things up to run locally like this:

https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/

I've been working with @tpenya on this one so he should know more or less what to do here (or how to ask me).